### PR TITLE
Fix mirrorz.d.json

### DIFF
--- a/lug/worker-script/mirrorz.py
+++ b/lug/worker-script/mirrorz.py
@@ -89,9 +89,9 @@ def main():
     mirrorz["mirrors"] = mirrors
     mirrorz["extension"] = "D"
     mirrorz["endpoints"] = [{
-        "label": "sjtug-" + site["tag"],
+        "label": "sjtug" + site["tag"],
         "public": True,
-        "resolve": site["url"],
+        "resolve": site["url"].strip("https://"),
         "filter": ["V4", "V6", "SSL", "NOSSL"],
         "range": [
             "202.120.0.0/18",


### PR DESCRIPTION
endpoints.url with https would result in

$ curl https://sjtugsiyuan.mirrors.cngi.edu.cn/ -I
HTTP/2 302
location: https://https://mirror.sjtu.edu.cn

Also, hyphen is trimmed according to https://github.com/mirrorz-org/mirrorz-302/commit/52b63a3664062e2efe7d20854da7f08da1de0a0d